### PR TITLE
Resolves #65: Add support for Selenium browser logging to propagation.

### DIFF
--- a/src/main/java/com/nordstrom/automation/selenium/core/JsUtility.java
+++ b/src/main/java/com/nordstrom/automation/selenium/core/JsUtility.java
@@ -244,7 +244,7 @@ public final class JsUtility {
      * 
      * @param exception web driver exception to propagate
      * @return nothing (this method always throws the specified exception)
-     * @deprecated at 17.3.0. The only driver that doesn't bury the original error is HtmlUnitDriver. 
+     * @deprecated at 17.3.0 
      */
     public static RuntimeException propagate(final WebDriverException exception) {
         throw propagate(null, exception);

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/PhantomJsCaps.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/PhantomJsCaps.java
@@ -14,7 +14,8 @@ public class PhantomJsCaps {
                     "{\"browserName\": \"phantomjs\", \"maxInstances\": 5, \"seleniumProtocol\": \"WebDriver\"}";
     
     public static final String BROWSER_NAME = "phantomjs";
-    public static final String PHANTOMJS = "{\"browserName\":\"phantomjs\"}";
+    public static final String BASELINE = "{\"browserName\":\"phantomjs\"}";
+    public static final String LOGGING = "{\"browserName\":\"phantomjs\", \"loggingPrefs\": {\"browser\": \"WARNING\"}}";
     
     private static final String[] PROPERTY_NAMES = {
                     "phantomjs.binary.path",
@@ -25,7 +26,8 @@ public class PhantomJsCaps {
     
     static {
         Map<String, String> personalities = new HashMap<>();
-        personalities.put(BROWSER_NAME, PHANTOMJS);
+        personalities.put(BROWSER_NAME, BASELINE);
+        personalities.put("phantomjs.logging", LOGGING);
         PERSONALITIES = Collections.unmodifiableMap(personalities);
     }
     

--- a/src/test/java/com/nordstrom/automation/selenium/core/JsUtilityTest.java
+++ b/src/test/java/com/nordstrom/automation/selenium/core/JsUtilityTest.java
@@ -89,7 +89,7 @@ public class JsUtilityTest extends TestNgBase {
             WebElement response = JsUtility.runAndReturn(driver, script, name);
             return response.getAttribute("content");
         } catch (WebDriverException e) {
-            throw JsUtility.propagate(e);
+            throw JsUtility.propagate(driver, e);
         }
     }
     


### PR DESCRIPTION
The PhantomJS driver captures JavaScript errors via an implementation of the Selenium logging framework. Messages from the errors don't get used as the preamble for the exception message as it does with other browsers. These revisions add a fallback to Selenium logging if the original WebDriverException lacks a serialized exception object.