### PR TITLE
Fix failure that occurred with local instances of HtmlUnitDriver 

### DIFF
--- a/selenium2Deps.gradle
+++ b/selenium2Deps.gradle
@@ -14,6 +14,7 @@ dependencies {
     exclude group: 'org.seleniumhq.selenium', module: 'selenium-java'
   }
   selenium2Compile 'org.seleniumhq.selenium:selenium-support:2.53.1'
-  selenium2Compile 'org.seleniumhq.selenium:htmlunit-driver:2.21'
+  selenium2Compile 'net.sourceforge.htmlunit:htmlunit:2.21'
+  testCompile 'org.seleniumhq.selenium:htmlunit-driver:2.21'
   testCompile 'org.mockito:mockito-core:2.25.0'
 }

--- a/src/main/java-s2/com/nordstrom/automation/selenium/plugins/ChromePlugin.java
+++ b/src/main/java-s2/com/nordstrom/automation/selenium/plugins/ChromePlugin.java
@@ -2,10 +2,9 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class ChromePlugin implements DriverPlugin {
+public class ChromePlugin extends RemoteWebDriverPlugin {
     
     /**
      * <b>org.openqa.selenium.chrome.ChromeDriver</b>

--- a/src/main/java-s2/com/nordstrom/automation/selenium/plugins/EdgePlugin.java
+++ b/src/main/java-s2/com/nordstrom/automation/selenium/plugins/EdgePlugin.java
@@ -2,10 +2,9 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class EdgePlugin implements DriverPlugin {
+public class EdgePlugin extends RemoteWebDriverPlugin {
     
     /**
      * <b>org.openqa.selenium.edge.EdgeDriver</b>

--- a/src/main/java-s2/com/nordstrom/automation/selenium/plugins/FirefoxPlugin.java
+++ b/src/main/java-s2/com/nordstrom/automation/selenium/plugins/FirefoxPlugin.java
@@ -2,10 +2,9 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class FirefoxPlugin implements DriverPlugin {
+public class FirefoxPlugin extends RemoteWebDriverPlugin {
     
     /**
      * For Selenium 2.53.1, use Firefox 47.0.1

--- a/src/main/java-s2/com/nordstrom/automation/selenium/plugins/HtmlUnitPlugin.java
+++ b/src/main/java-s2/com/nordstrom/automation/selenium/plugins/HtmlUnitPlugin.java
@@ -1,9 +1,16 @@
 package com.nordstrom.automation.selenium.plugins;
 
+import java.lang.reflect.Constructor;
 import java.util.Map;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
+
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.MethodCall;
 
 public class HtmlUnitPlugin implements DriverPlugin {
     
@@ -37,6 +44,9 @@ public class HtmlUnitPlugin implements DriverPlugin {
                     "org.eclipse.jetty.util.IO", "org.eclipse.jetty.io.EndPoint",
                     "org.eclipse.jetty.websocket.common.Parser",
                     "org.eclipse.jetty.websocket.api.Session"};
+    
+    private static final String WEB_ELEMENT_CLASS_NAME =
+            "org.openqa.selenium.htmlunit.HtmlUnitWebElement";
     
     /**
      * {@inheritDoc}
@@ -76,6 +86,22 @@ public class HtmlUnitPlugin implements DriverPlugin {
     @Override
     public String[] getPropertyNames() {
         return HtmlUnitCaps.getPropertyNames();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Implementation getWebElementCtor(WebDriver driver, Class<? extends WebElement> refClass) {
+        if (refClass.getName().equals(WEB_ELEMENT_CLASS_NAME)) {
+            try {
+                Constructor<?> ctor = refClass.getConstructors()[0];
+                return MethodCall.invoke(ctor).onSuper().with(driver).with((Object) null);
+            } catch (SecurityException e) {
+                // nothing to do here
+            }
+        }
+        return null;
     }
 
 }

--- a/src/main/java-s2/com/nordstrom/automation/selenium/plugins/InternetExplorerPlugin.java
+++ b/src/main/java-s2/com/nordstrom/automation/selenium/plugins/InternetExplorerPlugin.java
@@ -2,10 +2,9 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class InternetExplorerPlugin implements DriverPlugin {
+public class InternetExplorerPlugin extends RemoteWebDriverPlugin {
     
     /**
      * <a href='https://www.microsoft.com/en-au/download/confirmation.aspx?id=44069'>IE WebDriver Tools</a>

--- a/src/main/java-s2/com/nordstrom/automation/selenium/plugins/OperaPlugin.java
+++ b/src/main/java-s2/com/nordstrom/automation/selenium/plugins/OperaPlugin.java
@@ -2,10 +2,9 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class OperaPlugin implements DriverPlugin {
+public class OperaPlugin extends RemoteWebDriverPlugin {
     
     /**
      * For Selenium 2.53.1, use Opera 40 and operadriver 0.2.2

--- a/src/main/java-s2/com/nordstrom/automation/selenium/plugins/PhantomJsPlugin.java
+++ b/src/main/java-s2/com/nordstrom/automation/selenium/plugins/PhantomJsPlugin.java
@@ -2,10 +2,9 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class PhantomJsPlugin implements DriverPlugin {
+public class PhantomJsPlugin extends RemoteWebDriverPlugin {
     
     /**
      * <b>org.openqa.selenium.phantomjs.PhantomJSDriver</b>

--- a/src/main/java-s2/com/nordstrom/automation/selenium/plugins/SafariPlugin.java
+++ b/src/main/java-s2/com/nordstrom/automation/selenium/plugins/SafariPlugin.java
@@ -2,10 +2,9 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class SafariPlugin implements DriverPlugin {
+public class SafariPlugin extends RemoteWebDriverPlugin {
     
     /**
      * <b>org.openqa.selenium.safari.SafariDriver</b>

--- a/src/main/java-s3/com/nordstrom/automation/selenium/plugins/ChromePlugin.java
+++ b/src/main/java-s3/com/nordstrom/automation/selenium/plugins/ChromePlugin.java
@@ -2,18 +2,17 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class ChromePlugin implements DriverPlugin {
+public class ChromePlugin extends RemoteDriverPlugin {
     
     /**
      * <b>org.openqa.selenium.chrome.ChromeDriver</b>
      * 
      * <pre>&lt;dependency&gt;
-     *    &lt;groupId&gt;org.seleniumhq.selenium&lt;/groupId&gt;
-     *    &lt;artifactId&gt;selenium-chrome-driver&lt;/artifactId&gt;
-     *    &lt;version&gt;3.14.0&lt;/version&gt;
+     *  &lt;groupId&gt;org.seleniumhq.selenium&lt;/groupId&gt;
+     *  &lt;artifactId&gt;selenium-chrome-driver&lt;/artifactId&gt;
+     *  &lt;version&gt;3.141.59&lt;/version&gt;
      *&lt;/dependency&gt;</pre>
      */
     private static final String[] DEPENDENCY_CONTEXTS = {

--- a/src/main/java-s3/com/nordstrom/automation/selenium/plugins/EdgePlugin.java
+++ b/src/main/java-s3/com/nordstrom/automation/selenium/plugins/EdgePlugin.java
@@ -2,10 +2,9 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class EdgePlugin implements DriverPlugin {
+public class EdgePlugin extends RemoteDriverPlugin {
     
     /**
      * <b>org.openqa.selenium.edge.EdgeDriver</b>

--- a/src/main/java-s3/com/nordstrom/automation/selenium/plugins/FirefoxPlugin.java
+++ b/src/main/java-s3/com/nordstrom/automation/selenium/plugins/FirefoxPlugin.java
@@ -2,10 +2,9 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class FirefoxPlugin implements DriverPlugin {
+public class FirefoxPlugin extends RemoteDriverPlugin {
     
     /**
      * <b>org.openqa.selenium.firefox.FirefoxDriver</b>
@@ -13,7 +12,7 @@ public class FirefoxPlugin implements DriverPlugin {
      * <pre>&lt;dependency&gt;
      *  &lt;groupId&gt;org.seleniumhq.selenium&lt;/groupId&gt;
      *  &lt;artifactId&gt;selenium-firefox-driver&lt;/artifactId&gt;
-     *  &lt;version&gt;3.14.0&lt;/version&gt;
+     *  &lt;version&gt;3.141.59&lt;/version&gt;
      *&lt;/dependency&gt;</pre>
      */
     private static final String[] DEPENDENCY_CONTEXTS = {

--- a/src/main/java-s3/com/nordstrom/automation/selenium/plugins/HtmlUnitPlugin.java
+++ b/src/main/java-s3/com/nordstrom/automation/selenium/plugins/HtmlUnitPlugin.java
@@ -1,9 +1,16 @@
 package com.nordstrom.automation.selenium.plugins;
 
+import java.lang.reflect.Constructor;
 import java.util.Map;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 
 import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
+
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.MethodCall;
 
 public class HtmlUnitPlugin implements DriverPlugin {
     
@@ -35,6 +42,9 @@ public class HtmlUnitPlugin implements DriverPlugin {
                     "org.apache.commons.net.io.Util", "org.eclipse.jetty.client.Origin",
                     "org.eclipse.jetty.http.Syntax", "org.eclipse.jetty.xml.XmlParser",
                     "org.brotli.dec.Utils"};
+    
+    private static final String WEB_ELEMENT_CLASS_NAME =
+            "org.openqa.selenium.htmlunit.HtmlUnitWebElement";
     
     /**
      * {@inheritDoc}
@@ -74,6 +84,22 @@ public class HtmlUnitPlugin implements DriverPlugin {
     @Override
     public String[] getPropertyNames() {
         return HtmlUnitCaps.getPropertyNames();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Implementation getWebElementCtor(WebDriver driver, Class<? extends WebElement> refClass) {
+        if (refClass.getName().equals(WEB_ELEMENT_CLASS_NAME)) {
+            try {
+                Constructor<?> ctor = refClass.getConstructors()[0];
+                return MethodCall.invoke(ctor).onSuper().with(driver).with(Integer.valueOf(0)).with((Object) null);
+            } catch (SecurityException e) {
+                // nothing to do here
+            }
+        }
+        return null;
     }
 
 }

--- a/src/main/java-s3/com/nordstrom/automation/selenium/plugins/InternetExplorerPlugin.java
+++ b/src/main/java-s3/com/nordstrom/automation/selenium/plugins/InternetExplorerPlugin.java
@@ -2,10 +2,9 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class InternetExplorerPlugin implements DriverPlugin {
+public class InternetExplorerPlugin extends RemoteDriverPlugin {
     
     /**
      * <b>org.openqa.selenium.ie.InternetExplorerDriver</b>
@@ -13,7 +12,7 @@ public class InternetExplorerPlugin implements DriverPlugin {
      * <pre>&lt;dependency&gt;
      *  &lt;groupId&gt;org.seleniumhq.selenium&lt;/groupId&gt;
      *  &lt;artifactId&gt;selenium-ie-driver&lt;/artifactId&gt;
-     *  &lt;version&gt;3.14.0&lt;/version&gt;
+     *  &lt;version&gt;3.141.59&lt;/version&gt;
      *&lt;/dependency&gt;</pre>
      */
     private static final String[] DEPENDENCY_CONTEXTS = {

--- a/src/main/java-s3/com/nordstrom/automation/selenium/plugins/OperaPlugin.java
+++ b/src/main/java-s3/com/nordstrom/automation/selenium/plugins/OperaPlugin.java
@@ -2,10 +2,9 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class OperaPlugin implements DriverPlugin {
+public class OperaPlugin extends RemoteDriverPlugin {
     
     /**
      * <b>org.openqa.selenium.opera.OperaDriver</b>
@@ -13,7 +12,7 @@ public class OperaPlugin implements DriverPlugin {
      * <pre>&lt;dependency&gt;
      *  &lt;groupId&gt;org.seleniumhq.selenium&lt;/groupId&gt;
      *  &lt;artifactId&gt;selenium-opera-driver&lt;/artifactId&gt;
-     *  &lt;version&gt;3.14.0&lt;/version&gt;
+     *  &lt;version&gt;3.141.59&lt;/version&gt;
      *&lt;/dependency&gt;</pre>
      */
     private static final String[] DEPENDENCY_CONTEXTS = {

--- a/src/main/java-s3/com/nordstrom/automation/selenium/plugins/PhantomJsPlugin.java
+++ b/src/main/java-s3/com/nordstrom/automation/selenium/plugins/PhantomJsPlugin.java
@@ -2,10 +2,9 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class PhantomJsPlugin implements DriverPlugin {
+public class PhantomJsPlugin extends RemoteDriverPlugin {
     
     /**
      * <b>org.openqa.selenium.phantomjs.PhantomJSDriver</b>

--- a/src/main/java-s3/com/nordstrom/automation/selenium/plugins/SafariPlugin.java
+++ b/src/main/java-s3/com/nordstrom/automation/selenium/plugins/SafariPlugin.java
@@ -2,10 +2,9 @@ package com.nordstrom.automation.selenium.plugins;
 
 import java.util.Map;
 
-import com.nordstrom.automation.selenium.DriverPlugin;
 import com.nordstrom.automation.selenium.SeleniumConfig;
 
-public class SafariPlugin implements DriverPlugin {
+public class SafariPlugin extends RemoteDriverPlugin {
     
     /**
      * <b>org.openqa.selenium.safari.SafariDriver</b>
@@ -13,7 +12,7 @@ public class SafariPlugin implements DriverPlugin {
      * <pre>&lt;dependency&gt;
      *  &lt;groupId&gt;org.seleniumhq.selenium&lt;/groupId&gt;
      *  &lt;artifactId&gt;selenium-safari-driver&lt;/artifactId&gt;
-     *  &lt;version&gt;3.141.590&lt;/version&gt;
+     *  &lt;version&gt;3.141.59&lt;/version&gt;
      *&lt;/dependency&gt;</pre>
      */
     private static final String[] DEPENDENCY_CONTEXTS = {

--- a/src/main/java/com/nordstrom/automation/selenium/DriverPlugin.java
+++ b/src/main/java/com/nordstrom/automation/selenium/DriverPlugin.java
@@ -2,6 +2,11 @@ package com.nordstrom.automation.selenium;
 
 import java.util.Map;
 
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import net.bytebuddy.implementation.Implementation;
+
 public interface DriverPlugin {
     
     /**
@@ -39,5 +44,16 @@ public interface DriverPlugin {
      * @return System property names
      */
     String[] getPropertyNames();
+    
+    /**
+     * Get default constructor for this driver's {@link WebElement} implementation.
+     * <p>
+     * <b>NOTE</b>: This is only needed for implementations that use non-default constructors.
+     * 
+     * @param driver target driver instance
+     * @param refClass class of {@code WebDriver} implementation
+     * @return default constructor implementation
+     */
+    Implementation getWebElementCtor(WebDriver driver, Class<? extends WebElement> refClass);
     
 }

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/HtmlUnitCaps.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/HtmlUnitCaps.java
@@ -11,10 +11,10 @@ public class HtmlUnitCaps {
     }
 
     private static final String CAPABILITIES =
-                    "{\"browserName\":\"htmlunit\", \"browserVersion\":\"firefox-68\", \"maxInstances\":5, \"seleniumProtocol\":\"WebDriver\"}";
+                    "{\"browserName\":\"htmlunit\", \"browserVersion\":\"chrome\", \"maxInstances\":5, \"seleniumProtocol\":\"WebDriver\"}";
     
     public static final String BROWSER_NAME = "htmlunit";
-    public static final String BASELINE = "{\"browserName\":\"htmlunit\"}";
+    public static final String BASELINE = "{\"browserName\":\"htmlunit\", \"browserVersion\":\"chrome\"}";
     
     private static final String[] PROPERTY_NAMES = {  };
     

--- a/src/main/java/com/nordstrom/automation/selenium/plugins/RemoteWebDriverPlugin.java
+++ b/src/main/java/com/nordstrom/automation/selenium/plugins/RemoteWebDriverPlugin.java
@@ -1,0 +1,22 @@
+package com.nordstrom.automation.selenium.plugins;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import com.nordstrom.automation.selenium.DriverPlugin;
+
+import net.bytebuddy.implementation.Implementation;
+
+/**
+ * This class provides the base plugin implementation for drivers that extent {@code RemoteWebDriver}.
+ */
+public abstract class RemoteWebDriverPlugin implements DriverPlugin {
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Implementation getWebElementCtor(WebDriver driver, Class<? extends WebElement> refClass) {
+        return null;
+    }
+}


### PR DESCRIPTION
Attempts to execute **Selenium** tests with local **HtmlUnitDriver** sessions would blow up when **RobustElementFactory** tried to wrap instances of **HtmlUnitWebElement**, because this class has no default constructor. All of the other drivers supported by **Selenium Foundation** extend the **RemoteWebDriver** class, which generates instances of **RemoteWebElement** - a class that has a default constructor. To handle **WebElement** implementations with non-default constructors, I added a new method to the **DriverPlugin** interface that generates a method call to the requisite superclass constructor.